### PR TITLE
Updated plushies released until Jan 24th

### DIFF
--- a/plushies.json
+++ b/plushies.json
@@ -4224,19 +4224,19 @@
     88
   ],
   [
-    "Magical Yellow Kiko Plushie",
+    "Magical Yellow Squeeze Toy",
     99
   ],
   [
-    "Magical Blue Kiko Plushie",
+    "Magical Blue Squeeze Toy",
     99
   ],
   [
-    "Magical Red Kiko Plushie",
+    "Magical Red Squeeze Toy",
     99
   ],
   [
-    "Magical Green Kiko Plushie",
+    "Magical Green Squeeze Toy",
     99
   ],
   [
@@ -4386,6 +4386,81 @@
   [
     "Retro Striped Skeith Plushie",
     96
+  ],
+  [
+    "White Eyrie Plushie",
+    83
+  ],
+  [
+    "Snow Eyrie Plushie",
+    97
+  ],
+  [
+    "Magical Snow Eyrie Plushie",
+    99
+  ],
+  [
+    "Orange Eyrie Plushie",
+    81
+  ],
+  [
+    "Tyrannian Eyrie Plushie",
+    85
+  ],
+  [
+    "Golden Bori Plushie",
+    95
+  ],
+  [
+    "Magical Snow Bori Plushie",
+    99
+  ],
+  [
+    "Snow Bori Plushie",
+    96
+  ],
+  [
+    "Pink Halloween Cybunny Plushie",
+    84
+  ],
+  [
+    "Vintage Plushie Ixi Plushie",
+    99
+  ],
+  [
+    "Lavender Plushie Kau Plushie",
+    91
+  ],
+  [
+    "Plushie Ixi Plushie",
+    98
+  ],
+  [
+    "Magical Tyrannian Cybunny Plushie",
+    101
+  ],
+  [
+    "Plushie Usul Plushie",
+    90
+  ],
+  [
+    "Snow Usul Plushie",
+    88
+  ],
+  [
+    "Fire Usul Plushie",
+    87
+  ],
+  [
+    "Skunk Usul Plushie",
+    89
+  ],
+  [
+    "Shadow Korbat Plushie",
+    66
+  ],
+  [
+    "Purple Aisha Plushie",
+    87
   ]
-
 ]


### PR DESCRIPTION
I've checked the news posts and added all of the new ones.

Also took the liberty to some for those missing one's in general and compare against the list.
For example:

On usul day : **Plushie Usul Plushie** was released. So, I then searched for "Usul Plushie" and found entries like:

**Snow Usul Plushie** and **Fire Usul Plushie** missing from the list. So it's a bit more updated this way.